### PR TITLE
fix(docs): show `FwooshOptions` in docs

### DIFF
--- a/examples/docs/src/Welcome.stories.mdx
+++ b/examples/docs/src/Welcome.stories.mdx
@@ -38,9 +38,9 @@ Then create a `fwoosh.config.ts` file in the root of your project:
 ```ts fwoosh.config.ts
 import type { FwooshOptions } from "fwoosh";
 
-export const config: FwooshOptions = {
+export const config = {
   title: "My Design System",
-};
+} satisfies FwooshOptions;
 ```
 
 or if you're not using TypeScript, create a `fwoosh.config.mjs` instead:

--- a/examples/docs/src/Welcome.stories.mdx
+++ b/examples/docs/src/Welcome.stories.mdx
@@ -36,9 +36,9 @@ yarn add -D fwoosh
 Then create a `fwoosh.config.mjs` file in the root of your project:
 
 ```ts
-import { FwooshConfig } from "fwoosh";
+import { FwooshOptions } from "fwoosh";
 
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   title: "My Design System",
 };
 ```

--- a/examples/docs/src/Welcome.stories.mdx
+++ b/examples/docs/src/Welcome.stories.mdx
@@ -33,12 +33,35 @@ npm i --save-dev fwoosh
 yarn add -D fwoosh
 ```
 
-Then create a `fwoosh.config.mjs` file in the root of your project:
+Then create a `fwoosh.config.ts` file in the root of your project:
 
-```ts
-import { FwooshOptions } from "fwoosh";
+```ts fwoosh.config.ts
+import type { FwooshOptions } from "fwoosh";
 
 export const config: FwooshOptions = {
   title: "My Design System",
 };
 ```
+
+or if you're not using TypeScript, create a `fwoosh.config.mjs` instead:
+
+```js fwoosh.config.mjs
+export const config: FwooshOptions = {
+  title: "My Design System",
+};
+```
+
+## Getting started with React
+
+In order to start working with React, you'll need to install [`the React renderer`](../Plugins-Renderers-React) then add it to your plugins.
+
+```ts
+import type { FwooshOptions } from "fwoosh";
+
+export const config: FwooshOptions = {
+  title: "My Design System",
+  plugins: ["@fwoosh/react"],
+};
+```
+
+To see a complete example of configuring a more complex React app, check out the [example repo](https://github.com/fwoosh-dev/fwoosh/blob/main/examples/react/fwoosh.config.ts).

--- a/examples/docs/src/Welcome.stories.mdx
+++ b/examples/docs/src/Welcome.stories.mdx
@@ -46,10 +46,10 @@ export const config = {
 or if you're not using TypeScript, create a `fwoosh.config.mjs` instead:
 
 ```js fwoosh.config.mjs
-export const config: FwooshOptions = {
+/** @type {import("fwoosh").FwooshOptions} */ 
+export const config = {
   title: "My Design System",
 };
-```
 
 ## Getting started with React
 

--- a/examples/docs/src/components/Theming.stories.mdx
+++ b/examples/docs/src/components/Theming.stories.mdx
@@ -31,7 +31,7 @@ A theme is define like the following:
 You can either define the theme directly in your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   theme: [
     {
       type: "light",
@@ -48,7 +48,7 @@ export const config: FwooshConfig = {
 You can also use a path or a package name for configuring the theme.
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   theme: "@my-company/fwoosh-theme",
 };
 ```
@@ -103,7 +103,7 @@ Fwoosh offers the ability to take full control of most presentation and layout c
 You can add component overrides to Fwoosh by using the <Link to="Configuration#componentOverrides">`componentOverrides` options</Link>.
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   componentOverrides: "./path/to/componentOverrides.tsx",
 };
 ```

--- a/examples/docs/src/plugins/Plugins.stories.mdx
+++ b/examples/docs/src/plugins/Plugins.stories.mdx
@@ -20,7 +20,7 @@ There are four types of plugins:
 Plugins are configured in the `fwoosh.config.ts` file.
 
 ```ts fwoosh.config.ts focus=2:7
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: [
     // Just list the name of the plugin to use it
     "@fwoosh/panel-story-description",
@@ -36,7 +36,7 @@ This provides a better auto-complete experience in your editor.
 ```ts focus=1,5:7
 import StoryDescriptionPanel from "@fwoosh/panel-story-description";
 
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: [
     new StoryDescriptionPanel({
       title: "Comment",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fwoosh-monorepo",
   "private": true,
-  "description": "A lightening quick MDX static website generator!",
+  "description": "A lightning quick MDX static website generator!",
   "author": "Andrew Lisowski <lisowski54@gmail.com>",
   "workspaces": [
     "packages/*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "fwoosh",
   "type": "module",
   "version": "0.0.112",
-  "description": "A lightening quick component development",
+  "description": "A lightning quick component development",
   "main": "dist/index.js",
   "bin": "bin/fwoosh.js",
   "author": "Andrew Lisowski <lisowski54@gmail.com>",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -76,7 +76,7 @@ const sharedOptions: Option[] = [
 
 const fwooshCli: MultiCommand = {
   name,
-  description: "A lightening quick component development",
+  description: "A lightning quick component development",
   commands: [
     {
       name: "dev",

--- a/plugins/panel-actions/README.md
+++ b/plugins/panel-actions/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/panel-actions
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/panel-actions"],
 };
 ```

--- a/plugins/panel-designs/README.md
+++ b/plugins/panel-designs/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/panel-designs`
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/panel-designs`"],
 };
 ```

--- a/plugins/panel-props/README.md
+++ b/plugins/panel-props/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/panel-props
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/actions"],
 };
 ```

--- a/plugins/panel-source/README.md
+++ b/plugins/panel-source/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/panel-source
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/panel-source"],
 };
 ```

--- a/plugins/panel-story-description/README.md
+++ b/plugins/panel-story-description/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/panel-story-description
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/panel-story-description"],
 };
 ```

--- a/plugins/react/README.md
+++ b/plugins/react/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/react
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/react"],
 };
 ```

--- a/plugins/react/package.json
+++ b/plugins/react/package.json
@@ -2,7 +2,7 @@
   "name": "@fwoosh/react",
   "type": "module",
   "version": "0.0.112",
-  "description": "A lightening quick component development",
+  "description": "A lightning quick component development",
   "main": "./dist/index.js",
   "author": "Andrew Lisowski <lisowski54@gmail.com>",
   "repository": "hipstersmoothie/fwoosh",

--- a/plugins/tool-github/README.md
+++ b/plugins/tool-github/README.md
@@ -17,7 +17,7 @@ Then add it to your `fwoosh.config.ts`:
 ```ts fwoosh.config.ts
 import GitHubPlugin from "@fwoosh/tool-github";
 
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: [
     new GitHubPlugin({ repo: "fwooshjs/fwoosh" }),
     // or

--- a/plugins/tool-measure/README.md
+++ b/plugins/tool-measure/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/tool-measure
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/tool-measure"],
 };
 ```

--- a/plugins/tool-viewport/README.md
+++ b/plugins/tool-viewport/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/tool-viewport`
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/tool-viewport`"],
 };
 ```

--- a/plugins/tool-zoom/README.md
+++ b/plugins/tool-zoom/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/tool-zoom
 Then add it to your `fwoosh.config.ts`:
 
 ```ts fwoosh.config.ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/tool-zoom"],
 };
 ```

--- a/scripts/create/templates/panel/README.md
+++ b/scripts/create/templates/panel/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/{{kebab}}`
 Then add it to your `fwoosh.config.ts`:
 
 ```ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/{{kebab}}`"],
 };
 ```

--- a/scripts/create/templates/plugin/README.md
+++ b/scripts/create/templates/plugin/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/{{kebab}}`
 Then add it to your `fwoosh.config.ts`:
 
 ```ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/{{kebab}}`"],
 };
 ```

--- a/scripts/create/templates/tool/README.md
+++ b/scripts/create/templates/tool/README.md
@@ -15,7 +15,7 @@ yarn add -D @fwoosh/{{kebab}}`
 Then add it to your `fwoosh.config.ts`:
 
 ```ts
-export const config: FwooshConfig = {
+export const config: FwooshOptions = {
   plugins: ["@fwoosh/{{kebab}}`"],
 };
 ```


### PR DESCRIPTION
- rename `FwooshConfig` -> `FwooshOptions`
- typos
- adds a quick getting started blurb to the welcome page