### PR TITLE
Remove extra story watches

### DIFF
--- a/examples/react/fwoosh.config.ts
+++ b/examples/react/fwoosh.config.ts
@@ -12,7 +12,7 @@ import MeasurePanelPlugin from "@fwoosh/tool-measure";
 
 export const config = {
   title: "@fwoosh/react",
-  syntaxTheme: "material-ocean",
+  syntaxTheme: "poimandres",
   setup: path.resolve("./config/fwoosh-setup.ts"),
   theme: path.resolve("./config/fwoosh-theme.ts"),
   componentOverrides: path.resolve("./config/fwoosh-overrides.tsx"),

--- a/packages/app/src/components/Story.tsx
+++ b/packages/app/src/components/Story.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useId } from "@radix-ui/react-id";
+import { Helmet } from "react-helmet-async";
 
 import { styled } from "@fwoosh/styling";
-import { useRender } from "../hooks/useRender";
 import { stories } from "@fwoosh/app/stories";
-import { Helmet } from "react-helmet-async";
 import { useStoryId } from "@fwoosh/hooks";
+
+import { useRender } from "../hooks/useRender";
 
 export const StoryIdContext = React.createContext("");
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,6 @@
     "better-opn": "^3.0.2",
     "boxen": "^7.0.1",
     "change-case": "^4.1.2",
-    "chokidar": "^3.5.3",
     "command-line-application": "^0.10.1",
     "endent": "^2.1.0",
     "esbuild": "^0.17.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@types/express": "^4.17.17",
     "@types/express-ws": "^3.0.1",
-    "@types/lodash.debounce": "^4.0.7",
     "@types/micromatch": "^4.0.2",
     "@types/node": "^14.18.36",
     "@types/serve-handler": "^6.1.1",
@@ -48,7 +47,6 @@
     "hast": "^1.0.0",
     "hastscript": "^7.2.0",
     "lilconfig": "^2.0.6",
-    "lodash.debounce": "^4.0.8",
     "micromatch": "^4.0.5",
     "picomatch": "^2.3.1",
     "playwright": "1.30.0",

--- a/packages/cli/src/utils/story-list-plugin/index.ts
+++ b/packages/cli/src/utils/story-list-plugin/index.ts
@@ -1,5 +1,4 @@
 import { pascalCase } from "change-case";
-import chokidar from "chokidar";
 import {
   ParsedStoryData,
   FwooshOptionsLoaded,
@@ -7,8 +6,6 @@ import {
   BasicStoryData,
   Stories,
 } from "@fwoosh/types";
-import debounce from "lodash.debounce";
-import { ViteDevServer } from "vite";
 import { convertMetaTitleToUrlParam, log, sortTree } from "@fwoosh/utils";
 import { loadVirtualFile } from "@fwoosh/virtual-file";
 import { createRequire } from "module";
@@ -193,29 +190,6 @@ export function storyListPlugin(config: FwooshOptionsLoaded) {
         }
       }
       return;
-    },
-
-    configureServer(server: ViteDevServer) {
-      const storyWatcher = chokidar.watch(config.stories, {
-        persistent: true,
-        ignored: /node_modules/,
-        atomic: true,
-        ignoreInitial: true,
-      });
-
-      const reload = (type: string) =>
-        debounce(async (path: string) => {
-          const mod = await server.moduleGraph.getModuleByUrl(virtualFileId);
-
-          if (mod) {
-            log.warn(`Reloading, story "${type}" detected:`, path);
-            await server.reloadModule(mod);
-          }
-        }, 1000);
-
-      storyWatcher.on("add", reload("add"));
-      storyWatcher.on("change", reload("change"));
-      storyWatcher.on("unlink", reload("unlink"));
     },
   };
 }

--- a/plugins/panel-props/src/panel.tsx
+++ b/plugins/panel-props/src/panel.tsx
@@ -62,7 +62,7 @@ const placeholderBoxRow = (
 
 function PropsPanelSkeleton() {
   return (
-    <DelayedRender delay={2500}>
+    <DelayedRender delay={500}>
       <Wrapper>
         <components.p>
           <PlaceholderBox style={{ width: "80%" }} />

--- a/plugins/panel-props/src/panel.tsx
+++ b/plugins/panel-props/src/panel.tsx
@@ -13,10 +13,8 @@ const Wrapper = styled("div", {
 function PropsPanelContent({ storyId }: PanelPluginProps) {
   const [, story] =
     Object.entries(stories).find(([slug]) => slug === storyId) || [];
-  const docs = useDocgen(
-    storyId,
-    (story?.component as any)._result || story?.meta
-  );
+  const meta = story?.component?._payload?._result || story?.meta;
+  const docs = useDocgen(storyId, meta);
 
   return (
     <Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3811,15 +3811,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash.debounce@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "@types/lodash.debounce@npm:4.0.7"
-  dependencies:
-    "@types/lodash": "*"
-  checksum: e873b2d77f89010876baba3437ef826b17221b98948e00b5590828334a481dea1c8f9d28543210e564adc53199584f42c3cb171f8b6c3614fefc0b4e0888679c
-  languageName: node
-  linkType: hard
-
 "@types/lodash@npm:*":
   version: 4.14.191
   resolution: "@types/lodash@npm:4.14.191"
@@ -7127,7 +7118,6 @@ __metadata:
     "@swc/core": ^1.3.35
     "@types/express": ^4.17.17
     "@types/express-ws": ^3.0.1
-    "@types/lodash.debounce": ^4.0.7
     "@types/micromatch": ^4.0.2
     "@types/node": ^14.18.36
     "@types/serve-handler": ^6.1.1
@@ -7146,7 +7136,6 @@ __metadata:
     hast: ^1.0.0
     hastscript: ^7.2.0
     lilconfig: ^2.0.6
-    lodash.debounce: ^4.0.8
     micromatch: ^4.0.5
     picomatch: ^2.3.1
     playwright: 1.30.0
@@ -8851,13 +8840,6 @@ __metadata:
   version: 4.2.0
   resolution: "lodash.chunk@npm:4.2.0"
   checksum: 6286c6d06814fbeda502164015c42ef53a9194e6ebaac52ec2b41e83344aefe7bc3d94fdfec525adcd2c66cefdf05dc333b6a1128e4de739797342315c17cbc7
-  languageName: node
-  linkType: hard
-
-"lodash.debounce@npm:^4.0.8":
-  version: 4.0.8
-  resolution: "lodash.debounce@npm:4.0.8"
-  checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4318,16 +4318,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:~3.1.2":
-  version: 3.1.3
-  resolution: "anymatch@npm:3.1.3"
-  dependencies:
-    normalize-path: ^3.0.0
-    picomatch: ^2.0.4
-  checksum: 3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
-  languageName: node
-  linkType: hard
-
 "aproba@npm:^1.0.3 || ^2.0.0, aproba@npm:^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
@@ -4677,13 +4667,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-extensions@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "binary-extensions@npm:2.2.0"
-  checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
-  languageName: node
-  linkType: hard
-
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -4782,7 +4765,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2, braces@npm:~3.0.2":
+"braces@npm:^3.0.2":
   version: 3.0.2
   resolution: "braces@npm:3.0.2"
   dependencies:
@@ -5123,25 +5106,6 @@ __metadata:
   version: 1.0.2
   resolution: "check-error@npm:1.0.2"
   checksum: d9d106504404b8addd1ee3f63f8c0eaa7cd962a1a28eb9c519b1c4a1dc7098be38007fc0060f045ee00f075fbb7a2a4f42abcf61d68323677e11ab98dc16042e
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.5.3":
-  version: 3.5.3
-  resolution: "chokidar@npm:3.5.3"
-  dependencies:
-    anymatch: ~3.1.2
-    braces: ~3.0.2
-    fsevents: ~2.3.2
-    glob-parent: ~5.1.2
-    is-binary-path: ~2.1.0
-    is-glob: ~4.0.1
-    normalize-path: ~3.0.0
-    readdirp: ~3.6.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -7124,7 +7088,6 @@ __metadata:
     better-opn: ^3.0.2
     boxen: ^7.0.1
     change-case: ^4.1.2
-    chokidar: ^3.5.3
     command-line-application: ^0.10.1
     endent: ^2.1.0
     esbuild: ^0.17.7
@@ -7354,7 +7317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -8162,15 +8125,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-binary-path@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "is-binary-path@npm:2.1.0"
-  dependencies:
-    binary-extensions: ^2.0.0
-  checksum: 84192eb88cff70d320426f35ecd63c3d6d495da9d805b19bc65b518984b7c0760280e57dbf119b7e9be6b161784a5a673ab2c6abe83abb5198a432232ad5b35c
-  languageName: node
-  linkType: hard
-
 "is-buffer@npm:^1.1.5":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
@@ -8298,7 +8252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.1, is-glob@npm:~4.0.1":
+"is-glob@npm:^4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -10412,13 +10366,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
-  version: 3.0.0
-  resolution: "normalize-path@npm:3.0.0"
-  checksum: 88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
-  languageName: node
-  linkType: hard
-
 "not@npm:^0.1.0":
   version: 0.1.0
   resolution: "not@npm:0.1.0"
@@ -11250,7 +11197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
@@ -12048,15 +11995,6 @@ __metadata:
     micromatch: ^3.1.10
     readable-stream: ^2.0.2
   checksum: 3879b20f1a871e0e004a14fbf1776e65ee0b746a62f5a416010808b37c272ac49b023c47042c7b1e281cba75a449696635bc64c397ed221ea81d853a8f2ed79a
-  languageName: node
-  linkType: hard
-
-"readdirp@npm:~3.6.0":
-  version: 3.6.0
-  resolution: "readdirp@npm:3.6.0"
-  dependencies:
-    picomatch: ^2.2.1
-  checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
vite is doing a good job on it's own doing hmr. we don't need to help

closes  #63
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.119--canary.71.8a9c70c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @fwoosh/app@0.0.119--canary.71.8a9c70c.0
  npm install fwoosh@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/components@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/hooks@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/link@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/styling@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/test@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/types@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/utils@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/virtual-file@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/decorator-centered@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/pages@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/panel-actions@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/panel-designs@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/panel-props@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/panel-source@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/panel-story-description@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/react@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/theme-default@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/tool-github@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/tool-measure@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/tool-viewport@0.0.119--canary.71.8a9c70c.0
  npm install @fwoosh/tool-zoom@0.0.119--canary.71.8a9c70c.0
  # or 
  yarn add @fwoosh/app@0.0.119--canary.71.8a9c70c.0
  yarn add fwoosh@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/components@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/hooks@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/link@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/styling@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/test@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/types@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/utils@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/virtual-file@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/decorator-centered@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/pages@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/panel-actions@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/panel-designs@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/panel-props@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/panel-source@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/panel-story-description@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/react@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/theme-default@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/tool-github@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/tool-measure@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/tool-viewport@0.0.119--canary.71.8a9c70c.0
  yarn add @fwoosh/tool-zoom@0.0.119--canary.71.8a9c70c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
